### PR TITLE
Add LIBXML_NOCDATA

### DIFF
--- a/classes/Hobnob/XmlStreamReader/Parser.php
+++ b/classes/Hobnob/XmlStreamReader/Parser.php
@@ -387,7 +387,7 @@ class Parser
         //from invalid namespaces
         $data = new SimpleXMLElement(
             preg_replace('/^(<[^\s>]+)/', '$1'.$namespaceStr, $pathData),
-            LIBXML_COMPACT | LIBXML_NOERROR | LIBXML_NOWARNING
+            LIBXML_COMPACT | LIBXML_NOERROR | LIBXML_NOWARNING | LIBXML_NOCDATA
         );
 
         //Loop through each callback. If one of them stops the parsing


### PR DESCRIPTION
I'm having some issues parsing XML with CDATA. Adding this option converts the CDATA to string values.